### PR TITLE
Colorize "#" and "//" as comments even if there are no letters behind

### DIFF
--- a/syntaxes/vcl.tmLanguage.json
+++ b/syntaxes/vcl.tmLanguage.json
@@ -40,11 +40,11 @@
       "patterns": [
         {
           "name": "comment.line.number-sign.vcl",
-          "match": "#.+"
+          "match": "#.*"
         },
         {
           "name": "comment.line.double-slash.vcl",
-          "match": "//.+"
+          "match": "//.*"
         },
         {
           "name": "comment.line.block.vcl",

--- a/test/colorize-results/boilerplate_vcl.json
+++ b/test/colorize-results/boilerplate_vcl.json
@@ -864,19 +864,7 @@
 		}
 	},
 	{
-		"c": "  ",
-		"t": "source.vcl",
-		"r": {
-			"dark_plus": "default: #D4D4D4",
-			"light_plus": "default: #000000",
-			"dark_vs": "default: #D4D4D4",
-			"light_vs": "default: #000000",
-			"hc_black": "default: #FFFFFF",
-			"hc_light": "default: #292929"
-		}
-	},
-	{
-		"c": "#FASTLY hash",
+		"c": "  #FASTLY hash",
 		"t": "source.vcl keyword.control.vcl",
 		"r": {
 			"dark_plus": "keyword.control: #C586C0",


### PR DESCRIPTION
Fix for colorizing `#` and `//` as comments, even if there are no letters behind them.

There is a diff in the test result, but it’s not from this change.
It’s due to the current regex for macros that matches the preceding spaces of macro strings, and I think that’s not a problem.