### PR TITLE
Change the publisher metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-fastly-vcl",
   "displayName": "Fastly Varnish Configuration Language (VCL)",
   "description": "Syntax highlight Fastly Varnish Configuration Language (VCL) files",
-  "publisher": "Leon Brocard",
+  "publisher": "fastly",
   "homepage": "https://github.com/fastly/vscode-fastly-vcl",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
This change makes the publisher metadata "fastly" to match the Visual Studio Code Marketplace ID.