### PR TITLE
chore: exclude server test output from package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,6 +19,7 @@
 **/tsconfig.tsbuildinfo
 CLAUDE.md
 client/out/test/**
+server/out/test/**
 client/README.md
 client/src/**
 client/testFixture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "vscode-fastly-vcl" extension will be documented in t
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Exclude server test output (`server/out/test/**`) from the packaged extension
+
 ## [2.0.8] - 2026-01-30
 
 ### Changed


### PR DESCRIPTION
- Add server/out/test/** to .vscodeignore so test helpers no longer ship in the .vsix