### PR TITLE
Fix documentation link for std.replace_prefix

### DIFF
--- a/server/src/shared/utils.ts
+++ b/server/src/shared/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 
 export function slugify(str: string): string {
-  return str.replace(/\W+/g, "-").toLowerCase();
+  return str.replace(/[^A-Za-z0-9]/g, "-").toLowerCase();
 }
 
 export function ensureFullStop(str: string | undefined): string | undefined {


### PR DESCRIPTION
It was going to:
https://developer.fastly.com/reference/vcl/functions/strings/std-replace_prefix/

It should be going to:
https://developer.fastly.com/reference/vcl/functions/strings/std-replace-prefix/

This is because the character class `\W` is equivalent to `[^A-Za-z0-9_]`. Which is to say it wasn't replacing the underscore with a hyphen when constructing the URL.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes#:~:text=Non%2Dword%20character%20class%20escape

---

This substitution is required for other documentation links too. For example, check these functions with underscores all linking to a path with a hyphen:
https://www.fastly.com/documentation/reference/vcl/functions/table/

Fixes https://github.com/fastly/vscode-fastly-vcl/issues/112